### PR TITLE
Allow configuration to be injected into ProcessManager.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ install:
   - mkdir c:\test_temp
 
 test_script:
-  - php composer.phar test
+  - php composer.phar unit
 
 # environment variables
 environment:

--- a/src/Factory/DockerComposeTransportFactory.php
+++ b/src/Factory/DockerComposeTransportFactory.php
@@ -4,6 +4,7 @@ namespace Consolidation\SiteProcess\Factory;
 
 use Consolidation\SiteAlias\AliasRecord;
 use Consolidation\SiteProcess\Transport\DockerComposeTransport;
+use Consolidation\Config\ConfigInterface;
 
 /**
  * DockerComposeTransportFactory will create an DockerComposeTransport for
@@ -23,8 +24,8 @@ class DockerComposeTransportFactory implements TransportFactoryInterface
     /**
      * @inheritdoc
      */
-    public function create(AliasRecord $siteAlias)
+    public function create(AliasRecord $siteAlias, ConfigInterface $config)
     {
-        return new DockerComposeTransport($siteAlias);
+        return new DockerComposeTransport($siteAlias, $config);
     }
 }

--- a/src/Factory/SshTransportFactory.php
+++ b/src/Factory/SshTransportFactory.php
@@ -4,6 +4,7 @@ namespace Consolidation\SiteProcess\Factory;
 
 use Consolidation\SiteAlias\AliasRecord;
 use Consolidation\SiteProcess\Transport\SshTransport;
+use Consolidation\Config\ConfigInterface;
 
 /**
  * SshTransportFactory will create an SshTransport for applicable site aliases.
@@ -22,8 +23,8 @@ class SshTransportFactory implements TransportFactoryInterface
     /**
      * @inheritdoc
      */
-    public function create(AliasRecord $siteAlias)
+    public function create(AliasRecord $siteAlias, ConfigInterface $config)
     {
-        return new SshTransport($siteAlias);
+        return new SshTransport($siteAlias, $config);
     }
 }

--- a/src/Factory/TransportFactoryInterface.php
+++ b/src/Factory/TransportFactoryInterface.php
@@ -4,6 +4,7 @@ namespace Consolidation\SiteProcess\Factory;
 
 use Consolidation\SiteAlias\AliasRecord;
 use Consolidation\SiteProcess\Transport\TransportInterface;
+use Consolidation\Config\ConfigInterface;
 
 /**
  * TransportFactoryInterface defines a transport factory that is responsible
@@ -29,5 +30,5 @@ interface TransportFactoryInterface
      * @param AliasRecord $siteAlias
      * @return TransportInterface
      */
-    public function create(AliasRecord $siteAlias);
+    public function create(AliasRecord $siteAlias, ConfigInterface $config);
 }

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -9,6 +9,8 @@ use Consolidation\SiteProcess\Factory\DockerComposeTransportFactory;
 use Consolidation\SiteProcess\Factory\TransportFactoryInterface;
 use Consolidation\SiteProcess\Transport\LocalTransport;
 use Symfony\Component\Process\Process;
+use Consolidation\Config\Config;
+use Consolidation\Config\ConfigInterface;
 
 /**
  * ProcessManager will create a SiteProcess to run a command on a given
@@ -20,6 +22,12 @@ use Symfony\Component\Process\Process;
 class ProcessManager
 {
     protected $transportFactories = [];
+    protected $config;
+
+    public function __construct()
+    {
+        $this->config = new Config();
+    }
 
     /**
      * createDefault creates a Transport manager and add the default transports to it.
@@ -32,6 +40,14 @@ class ProcessManager
         $processManager->add(new DockerComposeTransportFactory());
 
         return $processManager;
+    }
+
+    /**
+     * Set a reference to the config object.
+     */
+    public function setConfig(ConfigInterface $config)
+    {
+        $this->config = $config;
     }
 
     /**
@@ -110,7 +126,7 @@ class ProcessManager
     {
         $factory = $this->getTransportFactory($siteAlias);
         if ($factory) {
-            return $factory->create($siteAlias);
+            return $factory->create($siteAlias, $this->config);
         }
         return new LocalTransport();
     }

--- a/src/Transport/DockerComposeTransport.php
+++ b/src/Transport/DockerComposeTransport.php
@@ -5,6 +5,7 @@ namespace Consolidation\SiteProcess\Transport;
 use Consolidation\SiteProcess\SiteProcess;
 use Consolidation\SiteAlias\AliasRecord;
 use Consolidation\SiteProcess\Util\Shell;
+use Consolidation\Config\ConfigInterface;
 
 /**
  * DockerComposeTransport knows how to wrap a command such that it executes
@@ -15,10 +16,12 @@ class DockerComposeTransport implements TransportInterface
     protected $tty;
     protected $siteAlias;
     protected $cd_remote;
+    protected $config;
 
-    public function __construct(AliasRecord $siteAlias)
+    public function __construct(AliasRecord $siteAlias, ConfigInterface $config)
     {
         $this->siteAlias = $siteAlias;
+        $this->config = $config;
     }
 
     /**
@@ -61,7 +64,7 @@ class DockerComposeTransport implements TransportInterface
     protected function getTransportOptions()
     {
         $transportOptions = [
-            $this->siteAlias->get('docker.service', ''),
+            $this->siteAlias->getConfig($this->config, 'docker.service', ''),
         ];
         if ($options = $this->siteAlias->get('docker.exec.options', '')) {
             array_unshift($transportOptions, Shell::preEscaped($options));

--- a/src/Transport/SshTransport.php
+++ b/src/Transport/SshTransport.php
@@ -6,6 +6,7 @@ use Consolidation\SiteProcess\SiteProcess;
 use Consolidation\SiteProcess\Util\Escape;
 use Consolidation\SiteAlias\AliasRecord;
 use Consolidation\SiteProcess\Util\Shell;
+use Consolidation\Config\ConfigInterface;
 
 /**
  * SshTransport knows how to wrap a command such that it runs on a remote
@@ -15,10 +16,12 @@ class SshTransport implements TransportInterface
 {
     protected $tty;
     protected $siteAlias;
+    protected $config;
 
-    public function __construct(AliasRecord $siteAlias)
+    public function __construct(AliasRecord $siteAlias, ConfigInterface $config)
     {
         $this->siteAlias = $siteAlias;
+        $this->config = $config;
     }
 
     /**
@@ -67,7 +70,7 @@ class SshTransport implements TransportInterface
     protected function getTransportOptions()
     {
         $transportOptions = [
-            Shell::preEscaped($this->siteAlias->get('ssh.options', '-o PasswordAuthentication=no')),
+            Shell::preEscaped($this->siteAlias->getConfig($this->config, 'ssh.options', '-o PasswordAuthentication=no')),
             $this->siteAlias->remoteHostWithUser(),
         ];
         if ($this->tty) {


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Has tests?    | not yet
| BC breaks?    | yes     
| Deprecations? | no 

### Summary
Inject configuration into the process manager

### Description
This allows us to provide default values in configuration for:
- ssh.options
- docker.service
- docker.exec.options

The b/c break is limited to an internal API when creating transports via a transport factory. Note also that this change causes dependency hell problems when mixing global Drush with a site-local Drush using a different version of site-process. We've already seen this happen with the site-alias project.