### PR TITLE
setWorkingDirectory() controls remote execution dir

### DIFF
--- a/src/ProcessBase.php
+++ b/src/ProcessBase.php
@@ -146,8 +146,8 @@ class ProcessBase extends Process
         $cmd = $this->getCommandLine();
         if ($this->isSimulated()) {
             $this->getLogger()->notice('Simulating: ' . $cmd);
-            // Run a command that always succeeds.
-            $this->setCommandLine('exit 0');
+            // Run a command that always succeeds (on Linux and Windows).
+            $this->setCommandLine('true');
         } elseif ($this->isVerbose()) {
             $this->getLogger()->info('Executing: ' . $cmd);
         }

--- a/src/SiteProcess.php
+++ b/src/SiteProcess.php
@@ -55,7 +55,7 @@ class SiteProcess extends ProcessBase
     public function setWorkingDirectory($cwd)
     {
         $this->cd = $cwd;
-        return parent::setWorkingDirectory($cwd);
+        return $this;
     }
 
     public function chdirToSiteRoot($shouldUseSiteRoot = true)
@@ -85,7 +85,7 @@ class SiteProcess extends ProcessBase
 
         // Ask the transport to drop in a 'cd' if needed.
         if ($this->cd) {
-            $selectedArgs = $transport->addChdir($this->cd, $selectedArgs);
+            $selectedArgs = $transport->addChdir($this->cd, $selectedArgs, $this);
         }
 
         // Do any necessary interpolation on the selected arguments.

--- a/src/SiteProcess.php
+++ b/src/SiteProcess.php
@@ -50,14 +50,28 @@ class SiteProcess extends ProcessBase
     }
 
     /**
-     * @inheritdoc
+     * @return string
      */
-    public function setWorkingDirectory($cwd)
+    public function getCd()
     {
-        $this->cd = $cwd;
-        return $this;
+        return $this->cd;
     }
 
+    /**
+     * @param string $cwd
+     */
+    public function setCd($cd)
+    {
+        $this->cd = $cd;
+    }
+
+    /**
+     *
+     * @param bool $shouldUseSiteRoot
+     * @return $this|\Symfony\Component\Process\Process
+     * @throws \Exception
+     * @deprecated.
+     */
     public function chdirToSiteRoot($shouldUseSiteRoot = true)
     {
         if (!$shouldUseSiteRoot || !$this->siteAlias->hasRoot()) {

--- a/src/SiteProcess.php
+++ b/src/SiteProcess.php
@@ -30,7 +30,7 @@ class SiteProcess extends ProcessBase
     /** @var string[] */
     protected $optionsPassedAsArgs;
     /** @var string */
-    protected $cd;
+    protected $cd_remote;
     /** @var TransportInterface */
     protected $transport;
 
@@ -50,19 +50,44 @@ class SiteProcess extends ProcessBase
     }
 
     /**
-     * @return string
+     * Get a starting directory for the remote process.
+     *
+     * @return string|null
      */
-    public function getCd()
-    {
-        return $this->cd;
+    public function getWorkingDirectory() {
+        return $this->cd_remote;
     }
 
     /**
-     * @param string $cwd
+     * Set a starting directory for the remote process.
+     *
+     * @param string $cd_remote
+     *
+     * @return \Consolidation\SiteProcess\SiteProcess
      */
-    public function setCd($cd)
-    {
-        $this->cd = $cd;
+    public function setWorkingDirectory($cd_remote) {
+        $this->cd_remote = $cd_remote;
+        return $this;
+    }
+
+    /**
+     * Set a starting directory for the initial/local process.
+     *
+     * @param string $cd
+     *
+     * @return \Consolidation\SiteProcess\SiteProcess
+     */
+    public function setWorkingDirectoryLocal($cd) {
+        return parent::setWorkingDirectory($cd);
+    }
+
+    /**
+     * Get the starting directory for the initial/local process.
+     *
+     * @return string|null;
+     */
+    public function getWorkingDirectoryLocal() {
+        return parent::getWorkingDirectory();
     }
 
     /**
@@ -70,7 +95,6 @@ class SiteProcess extends ProcessBase
      * @param bool $shouldUseSiteRoot
      * @return $this|\Symfony\Component\Process\Process
      * @throws \Exception
-     * @deprecated.
      */
     public function chdirToSiteRoot($shouldUseSiteRoot = true)
     {
@@ -98,8 +122,8 @@ class SiteProcess extends ProcessBase
         );
 
         // Ask the transport to drop in a 'cd' if needed.
-        if ($this->cd) {
-            $selectedArgs = $transport->addChdir($this->cd, $selectedArgs);
+        if ($this->getWorkingDirectory()) {
+            $selectedArgs = $transport->addChdir($this->getWorkingDirectory(), $selectedArgs);
         }
 
         // Do any necessary interpolation on the selected arguments.

--- a/src/SiteProcess.php
+++ b/src/SiteProcess.php
@@ -54,7 +54,8 @@ class SiteProcess extends ProcessBase
      *
      * @return string|null
      */
-    public function getWorkingDirectory() {
+    public function getWorkingDirectory()
+    {
         return $this->cd_remote;
     }
 
@@ -65,7 +66,8 @@ class SiteProcess extends ProcessBase
      *
      * @return \Consolidation\SiteProcess\SiteProcess
      */
-    public function setWorkingDirectory($cd_remote) {
+    public function setWorkingDirectory($cd_remote)
+    {
         $this->cd_remote = $cd_remote;
         return $this;
     }
@@ -77,7 +79,8 @@ class SiteProcess extends ProcessBase
      *
      * @return \Consolidation\SiteProcess\SiteProcess
      */
-    public function setWorkingDirectoryLocal($cd) {
+    public function setWorkingDirectoryLocal($cd)
+    {
         return parent::setWorkingDirectory($cd);
     }
 
@@ -86,7 +89,8 @@ class SiteProcess extends ProcessBase
      *
      * @return string|null;
      */
-    public function getWorkingDirectoryLocal() {
+    public function getWorkingDirectoryLocal()
+    {
         return parent::getWorkingDirectory();
     }
 

--- a/src/SiteProcess.php
+++ b/src/SiteProcess.php
@@ -99,7 +99,7 @@ class SiteProcess extends ProcessBase
 
         // Ask the transport to drop in a 'cd' if needed.
         if ($this->cd) {
-            $selectedArgs = $transport->addChdir($this->cd, $selectedArgs, $this);
+            $selectedArgs = $transport->addChdir($this->cd, $selectedArgs);
         }
 
         // Do any necessary interpolation on the selected arguments.

--- a/src/Transport/DockerComposeTransport.php
+++ b/src/Transport/DockerComposeTransport.php
@@ -53,7 +53,7 @@ class DockerComposeTransport implements TransportInterface
     /**
      * @inheritdoc
      */
-    public function addChdir($cd, $arg)
+    public function addChdir($cd, $args)
     {
         $this->cd = $cd;
         return $args;

--- a/src/Transport/DockerComposeTransport.php
+++ b/src/Transport/DockerComposeTransport.php
@@ -53,7 +53,7 @@ class DockerComposeTransport implements TransportInterface
     /**
      * @inheritdoc
      */
-    public function addChdir($cd, $args)
+    public function addChdir($cd, $arg, $process)
     {
         $this->cd = $cd;
         return $args;

--- a/src/Transport/DockerComposeTransport.php
+++ b/src/Transport/DockerComposeTransport.php
@@ -53,7 +53,7 @@ class DockerComposeTransport implements TransportInterface
     /**
      * @inheritdoc
      */
-    public function addChdir($cd, $arg, $process)
+    public function addChdir($cd, $arg)
     {
         $this->cd = $cd;
         return $args;

--- a/src/Transport/DockerComposeTransport.php
+++ b/src/Transport/DockerComposeTransport.php
@@ -14,7 +14,7 @@ class DockerComposeTransport implements TransportInterface
 {
     protected $tty;
     protected $siteAlias;
-    protected $cd;
+    protected $cd_remote;
 
     public function __construct(AliasRecord $siteAlias)
     {
@@ -50,7 +50,7 @@ class DockerComposeTransport implements TransportInterface
      */
     public function addChdir($cd, $args)
     {
-        $this->cd = $cd;
+        $this->cd_remote = $cd;
         return $args;
     }
 
@@ -69,8 +69,8 @@ class DockerComposeTransport implements TransportInterface
         if (!$this->tty) {
             array_unshift($transportOptions, '-T');
         }
-        if ($this->cd) {
-            $transportOptions = array_merge(['--workdir', $this->cd], $transportOptions);
+        if ($this->cd_remote) {
+            $transportOptions = array_merge(['--workdir', $this->cd_remote], $transportOptions);
         }
         return array_filter($transportOptions);
     }

--- a/src/Transport/DockerComposeTransport.php
+++ b/src/Transport/DockerComposeTransport.php
@@ -2,12 +2,7 @@
 
 namespace Consolidation\SiteProcess\Transport;
 
-use Psr\Log\LoggerInterface;
-use Symfony\Component\Console\Style\OutputStyle;
-use Symfony\Component\Process\Process;
-use Consolidation\SiteProcess\Util\RealtimeOutputHandler;
-use Consolidation\SiteProcess\Util\Escape;
-use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Consolidation\SiteProcess\SiteProcess;
 use Consolidation\SiteAlias\AliasRecord;
 use Consolidation\SiteProcess\Util\Shell;
 
@@ -27,15 +22,15 @@ class DockerComposeTransport implements TransportInterface
     }
 
     /**
-     * inheritdoc
+     * @inheritdoc
      */
-    public function configure(Process $process)
+    public function configure(SiteProcess $process)
     {
         $this->tty = $process->isTty();
     }
 
     /**
-     * inheritdoc
+     * @inheritdoc
      */
     public function wrap($args)
     {

--- a/src/Transport/LocalTransport.php
+++ b/src/Transport/LocalTransport.php
@@ -2,21 +2,19 @@
 
 namespace Consolidation\SiteProcess\Transport;
 
-use Symfony\Component\Process\Process;
+use Consolidation\SiteProcess\SiteProcess;
 
 /**
  * LocalTransport just runs the command on the local system.
  */
 class LocalTransport implements TransportInterface
 {
-    protected $process;
-
     /**
      * @inheritdoc
      */
-    public function configure(Process $process)
+    public function configure(SiteProcess $process)
     {
-        $this->process = $process;
+        $process->setWorkingDirectory($process->getCd());
     }
 
     /**
@@ -32,7 +30,6 @@ class LocalTransport implements TransportInterface
      */
     public function addChdir($cd, $args)
     {
-        $this->process->setWorkingDirectory($cd);
         return $args;
     }
 }

--- a/src/Transport/LocalTransport.php
+++ b/src/Transport/LocalTransport.php
@@ -27,8 +27,9 @@ class LocalTransport implements TransportInterface
     /**
      * @inheritdoc
      */
-    public function addChdir($cd, $args)
+    public function addChdir($cd, $args, $process)
     {
+        $process->setWorkingDirectory($cd);
         return $args;
     }
 }

--- a/src/Transport/LocalTransport.php
+++ b/src/Transport/LocalTransport.php
@@ -9,11 +9,14 @@ use Symfony\Component\Process\Process;
  */
 class LocalTransport implements TransportInterface
 {
+    protected $process;
+
     /**
      * @inheritdoc
      */
     public function configure(Process $process)
     {
+        $this->process = $process;
     }
 
     /**
@@ -27,9 +30,9 @@ class LocalTransport implements TransportInterface
     /**
      * @inheritdoc
      */
-    public function addChdir($cd, $args, $process)
+    public function addChdir($cd, $args)
     {
-        $process->setWorkingDirectory($cd);
+        $this->process->setWorkingDirectory($cd);
         return $args;
     }
 }

--- a/src/Transport/LocalTransport.php
+++ b/src/Transport/LocalTransport.php
@@ -14,7 +14,7 @@ class LocalTransport implements TransportInterface
      */
     public function configure(SiteProcess $process)
     {
-        $process->setWorkingDirectory($process->getCd());
+        $process->setWorkingDirectoryLocal($process->getWorkingDirectory());
     }
 
     /**

--- a/src/Transport/SshTransport.php
+++ b/src/Transport/SshTransport.php
@@ -52,7 +52,7 @@ class SshTransport implements TransportInterface
     /**
      * @inheritdoc
      */
-    public function addChdir($cd, $args, $process)
+    public function addChdir($cd, $args)
     {
         return array_merge(
             [

--- a/src/Transport/SshTransport.php
+++ b/src/Transport/SshTransport.php
@@ -2,12 +2,8 @@
 
 namespace Consolidation\SiteProcess\Transport;
 
-use Psr\Log\LoggerInterface;
-use Symfony\Component\Console\Style\OutputStyle;
-use Symfony\Component\Process\Process;
-use Consolidation\SiteProcess\Util\RealtimeOutputHandler;
+use Consolidation\SiteProcess\SiteProcess;
 use Consolidation\SiteProcess\Util\Escape;
-use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Consolidation\SiteAlias\AliasRecord;
 use Consolidation\SiteProcess\Util\Shell;
 
@@ -26,9 +22,9 @@ class SshTransport implements TransportInterface
     }
 
     /**
-     * inheritdoc
+     * @inheritdoc
      */
-    public function configure(Process $process)
+    public function configure(SiteProcess $process)
     {
         $this->tty = $process->isTty();
     }

--- a/src/Transport/SshTransport.php
+++ b/src/Transport/SshTransport.php
@@ -48,12 +48,12 @@ class SshTransport implements TransportInterface
     /**
      * @inheritdoc
      */
-    public function addChdir($cd, $args)
+    public function addChdir($cd_remote, $args)
     {
         return array_merge(
             [
                 'cd',
-                $cd,
+                $cd_remote,
                 Shell::op('&&'),
             ],
             $args

--- a/src/Transport/SshTransport.php
+++ b/src/Transport/SshTransport.php
@@ -52,7 +52,7 @@ class SshTransport implements TransportInterface
     /**
      * @inheritdoc
      */
-    public function addChdir($cd, $args)
+    public function addChdir($cd, $args, $process)
     {
         return array_merge(
             [

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -34,5 +34,5 @@ interface TransportInterface
     /**
      * addChdir adds an appropriate 'chdir' / 'cd' command for the transport.
      */
-    public function addChdir($cd, $args, $process);
+    public function addChdir($cd, $args);
 }

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -34,5 +34,5 @@ interface TransportInterface
     /**
      * addChdir adds an appropriate 'chdir' / 'cd' command for the transport.
      */
-    public function addChdir($cd, $args);
+    public function addChdir($cd, $args, $process);
 }

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -2,22 +2,26 @@
 
 namespace Consolidation\SiteProcess\Transport;
 
-use Symfony\Component\Process\Process;
+use Consolidation\SiteProcess\SiteProcess;
 
 /**
  * SshTransport knows how to wrap a command such that it runs on a remote
  * system via the ssh cli.
  *
  * There is always a transport for every factory, and visa-versa.
+ *
  * @see Consolidation\SiteProcess\Factory\TransportFactoryInterface
  */
 interface TransportInterface
 {
+
     /**
      * Configure ourselves based on the settings of the process object
      * (e.g. isTty()).
+     *
+     * @param \Consolidation\SiteProcess\SiteProcess $process
      */
-    public function configure(Process $process);
+    public function configure(SiteProcess $process);
 
     /**
      * wrapWithTransport examines the provided site alias; if it is a local

--- a/tests/SiteProcessTest.php
+++ b/tests/SiteProcessTest.php
@@ -164,12 +164,9 @@ class SiteProcessTest extends TestCase
         $siteAlias = new AliasRecord($siteAliasData, '@alias.dev');
         $siteProcess = $processManager->siteProcess($siteAlias, $args, $options, $optionsPassedAsArgs);
         $siteProcess->setTty($useTty);
-        if ($cd) {
-            $siteProcess->setWorkingDirectory($cd);
-        }
-        else {
-            $siteProcess->chdirToSiteRoot();
-        }
+        // The transport handles the chdir during processArgs().
+        $fallback = $siteAlias->hasRoot() ? $siteAlias->root() : null;
+        $siteProcess->setCd($cd ?: $fallback);
 
         $actual = $siteProcess->getCommandLine();
         $this->assertEquals($expected, $actual);

--- a/tests/SiteProcessTest.php
+++ b/tests/SiteProcessTest.php
@@ -166,7 +166,7 @@ class SiteProcessTest extends TestCase
         $siteProcess->setTty($useTty);
         // The transport handles the chdir during processArgs().
         $fallback = $siteAlias->hasRoot() ? $siteAlias->root() : null;
-        $siteProcess->setCd($cd ?: $fallback);
+        $siteProcess->setWorkingDirectory($cd ?: $fallback);
 
         $actual = $siteProcess->getCommandLine();
         $this->assertEquals($expected, $actual);


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | yes (in drush)
| BC breaks?    | no     
| Deprecations? | no 

### Summary

The current implementation does a setWorkingDirectory() even when the resulting Process is targetting a remote site. Thats not desireable at all, since the directory may be meant for a remote machine.

This PR removes calls to setWorkingDirectory instead relies on the Transport to do this. LocalTransport is the only one to do so.
