### PR TITLE
Add a separaate 'addTransports' method 

### DIFF
--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -57,7 +57,15 @@ class ProcessManager implements ConfigAwareInterface
     public static function createDefault()
     {
         $processManager = new self();
+        return static::addTransports($processManager);
+    }
 
+    /**
+     * addTransports adds the avaiable transports to the
+     * provided process manager.
+     */
+    public static function addTransports(ProcessManager $processManager)
+    {
         $processManager->add(new SshTransportFactory());
         $processManager->add(new DockerComposeTransportFactory());
 


### PR DESCRIPTION
For clients that wish to subclass the process manager.
