### PR TITLE
Add ability to run docker-compose with defined projects

### DIFF
--- a/src/Transport/DockerComposeTransport.php
+++ b/src/Transport/DockerComposeTransport.php
@@ -35,7 +35,7 @@ class DockerComposeTransport implements TransportInterface
      */
     public function wrap($args)
     {
-        $transport = ['docker-compose', 'exec'];
+        $transport = $this->getTransport();
         $transportOptions = $this->getTransportOptions();
         $commandToExecute = $this->getCommandToExecute($args);
 
@@ -53,6 +53,19 @@ class DockerComposeTransport implements TransportInterface
     {
         $this->cd_remote = $cd;
         return $args;
+    }
+
+    /**
+     * getTransport returns the transport along with the docker-compose
+     * project in case it is defined.
+     */
+    protected function getTransport()
+    {
+        $transport = ['docker-compose'];
+        if ($project = $this->siteAlias->get('docker.project', '')) {
+            $transport = array_merge($transport, ['-p', $project]);
+        }
+        return array_merge($transport, ['exec']);
     }
 
     /**

--- a/tests/SiteProcessTest.php
+++ b/tests/SiteProcessTest.php
@@ -126,6 +126,17 @@ class SiteProcessTest extends TestCase
             ],
 
             [
+                "docker-compose -p project exec --workdir src --user root drupal ls -al /path1 /path2",
+                'src',
+                true,
+                ['docker' => ['service' => 'drupal', 'project' => 'project', 'exec' => ['options' => '--user root']]],
+                ['ls', '-al', '/path1', '/path2'],
+                [],
+                [],
+                NULL,
+            ],
+
+            [
                 "drush status '--fields=root,uri'",
                 false,
                 false,


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Added the option to use a project name for the Docker Compose Transport.

### Description
Close drush-ops/drush#4012

sample yml file:
```yml
dev:
  root: /var/www/web
  uri: http://localhost
  docker:
    service: drupal
    project: portfolio
```