### PR TITLE
Allow passing the file to docker-compose.yml and any other docker-compose arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 2.0.2 -
+* When the transport is Docker, allow setting any docker-compose flags in the alias file
+
 ### 2.0.1 - 2019/Apr/2
 
 * Do not format output in RealTimeOutput

--- a/README.md
+++ b/README.md
@@ -32,6 +32,50 @@ This is equivalent to:
 ```
 $process = $processManager->siteProcess($site_alias, ['git', '--untracked-files=no', 'status']);
 ```
+### Transports
+#### SSH
+Wraps a command so that it runs on a remote system via the ssh cli.
+
+Example:
+```yaml
+local:
+  host: localhost
+  uri: http://localhost
+  ssh:
+    options: -o PasswordAuthentication=no -i $HOME/.ssh/id_rsa 
+
+```
+#### Docker Compose
+Wraps a command so that it runs on a remote system via docker-compose.
+
+Example:
+```yaml
+local:
+  host: localhost
+  uri: http://localhost
+  docker:
+    service: drupal
+    project: dockerComposeProjectName
+    compose:
+      options: --project dockerComposeProjectName --file docker-compose.yml --project-directory dockerComposeWorkDir
+    exec:
+      options: --user www-data
+
+```
+
+The above would execute commands prefixed with:
+```
+docker-compose --project dockerComposeProjectName --file docker-compose.yml --project-directory dockerComposeWorkDir exec --user www-data -T drupal
+```
+
+`docker.project` and `compose.options --project` do the same thing, docker.project existed before options.
+
+`docker.service` is the exact name of the service as it appears in docker-compos.yml
+
+Check the [docker-compose](https://docs.docker.com/compose/reference/overview/) manual for all available options.
+
+#### Local
+Runs the command on the local system.
 
 ## Symfony 4
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ local:
   uri: http://localhost
   docker:
     service: drupal
-    project: dockerComposeProjectName
     compose:
       options: --project dockerComposeProjectName --file docker-compose.yml --project-directory dockerComposeWorkDir
     exec:

--- a/src/Transport/DockerComposeTransport.php
+++ b/src/Transport/DockerComposeTransport.php
@@ -62,8 +62,8 @@ class DockerComposeTransport implements TransportInterface
     protected function getTransport()
     {
         $transport = ['docker-compose'];
-        if ($project = $this->siteAlias->get('docker.project', '')) {
-            $transport = array_merge($transport, ['-p', $project]);
+        if ($options = $this->siteAlias->get('docker.compose.options', '')) {
+            $transport[] = Shell::preEscaped($options);
         }
         return array_merge($transport, ['exec']);
     }

--- a/src/Transport/DockerComposeTransport.php
+++ b/src/Transport/DockerComposeTransport.php
@@ -62,6 +62,9 @@ class DockerComposeTransport implements TransportInterface
     protected function getTransport()
     {
         $transport = ['docker-compose'];
+        if ($project = $this->siteAlias->get('docker.project', '')) {
+            $transport = array_merge($transport, ['-p', $project]);
+        }
         if ($options = $this->siteAlias->get('docker.compose.options', '')) {
             $transport[] = Shell::preEscaped($options);
         }

--- a/src/Transport/DockerComposeTransport.php
+++ b/src/Transport/DockerComposeTransport.php
@@ -62,10 +62,12 @@ class DockerComposeTransport implements TransportInterface
     protected function getTransport()
     {
         $transport = ['docker-compose'];
-        if ($project = $this->siteAlias->get('docker.project', '')) {
+        $project = $this->siteAlias->get('docker.project', '');
+        $options = $this->siteAlias->get('docker.compose.options', '');
+        if ($project && (strpos($options, '-p') === false || strpos($options, '--project') === false)) {
             $transport = array_merge($transport, ['-p', $project]);
         }
-        if ($options = $this->siteAlias->get('docker.compose.options', '')) {
+        if ($options) {
             $transport[] = Shell::preEscaped($options);
         }
         return array_merge($transport, ['exec']);

--- a/tests/SiteProcessTest.php
+++ b/tests/SiteProcessTest.php
@@ -129,7 +129,7 @@ class SiteProcessTest extends TestCase
                 "docker-compose -p project exec --workdir src --user root drupal ls -al /path1 /path2",
                 'src',
                 true,
-                ['docker' => ['service' => 'drupal', 'project' => 'project', 'exec' => ['options' => '--user root']]],
+                ['docker' => ['service' => 'drupal', 'compose' => ['options' => '-p project'], 'exec' => ['options' => '--user root']]],
                 ['ls', '-al', '/path1', '/path2'],
                 [],
                 [],

--- a/tests/SiteProcessTest.php
+++ b/tests/SiteProcessTest.php
@@ -129,7 +129,7 @@ class SiteProcessTest extends TestCase
                 "docker-compose -p project exec --workdir src --user root drupal ls -al /path1 /path2",
                 'src',
                 true,
-                ['docker' => ['service' => 'drupal', 'compose' => ['options' => '-p project'], 'exec' => ['options' => '--user root']]],
+                ['docker' => ['service' => 'drupal', 'project' => 'project', 'exec' => ['options' => '--user root']]],
                 ['ls', '-al', '/path1', '/path2'],
                 [],
                 [],

--- a/tests/Transport/DockerComposeTransportTest.php
+++ b/tests/Transport/DockerComposeTransportTest.php
@@ -22,7 +22,6 @@ class DockerComposeTransportTest extends TestCase
                         'compose' => [
                             'options' => '--project project --project-directory projectDir --file myCompose.yml'
                         ],
-                        'file' => 'docker-compose.yml',
                         'exec' => ['options' => '--user root']
                     ]
                 ],
@@ -32,6 +31,30 @@ class DockerComposeTransportTest extends TestCase
                 [
                     'docker' => [
                         'service' => 'drupal',
+                    ]
+                ],
+            ],
+            [
+                'docker-compose --project project2 --file myCompose.yml exec -T drupal ls',
+                [
+                    'docker' => [
+                        'service' => 'drupal',
+                        'project' => 'project1',
+                        'compose' => [
+                            'options' => '--project project2 --file myCompose.yml'
+                        ]
+                    ]
+                ],
+            ],
+            [
+                'docker-compose -p project1 --file myCompose.yml exec -T drupal ls',
+                [
+                    'docker' => [
+                        'service' => 'drupal',
+                        'project' => 'project1',
+                        'compose' => [
+                            'options' => '--file myCompose.yml'
+                        ]
                     ]
                 ],
             ],

--- a/tests/Transport/DockerComposeTransportTest.php
+++ b/tests/Transport/DockerComposeTransportTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Consolidation\SiteProcess;
+
+use Consolidation\SiteProcess\Transport\DockerComposeTransport;
+use PHPUnit\Framework\TestCase;
+use Consolidation\SiteAlias\SiteAlias;
+
+class DockerComposeTransportTest extends TestCase
+{
+    /**
+     * Data provider for testWrap.
+     */
+    public function wrapTestValues()
+    {
+        return [
+            [
+                'docker-compose --project project --project-directory projectDir --file myCompose.yml exec -T --user root drupal ls',
+                [
+                    'docker' => [
+                        'service' => 'drupal',
+                        'compose' => [
+                            'options' => '--project project --project-directory projectDir --file myCompose.yml'
+                        ],
+                        'file' => 'docker-compose.yml',
+                        'exec' => ['options' => '--user root']
+                    ]
+                ],
+            ],
+            [
+                'docker-compose exec -T drupal ls',
+                [
+                    'docker' => [
+                        'service' => 'drupal',
+                    ]
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider wrapTestValues
+     */
+    public function testWrap($expected, $siteAliasData)
+    {
+        $siteAlias = new SiteAlias($siteAliasData, '@alias.dev');
+        $dockerTransport = new DockerComposeTransport($siteAlias);
+        $actual = $dockerTransport->wrap(['ls']);
+        $this->assertEquals($expected, implode(' ', $actual));
+    }
+}


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | no 

### Summary
For reference, the docker transport is launching a docker-compose command, for which the syntax is:
docker compose [compose flags] exec [exec flags].

Before this PR, exec flags can be set in the drush alias file as a single string, this PR allows the same thing for docker-compose flags.

### Description
An improvement here was recently merged in #37 but I need to specify the path to the docker compose yml file as well. I feel that the best approach is to not tie this to docker-compose arguments, so allow any arguments like it's done for the exec command.


