### PR TITLE
Use posix_isatty if it is available.

### DIFF
--- a/src/Util/Tty.php
+++ b/src/Util/Tty.php
@@ -15,6 +15,10 @@ class Tty
      */
     public static function isTtySupported()
     {
+        // Start off by checking STDIN with `posix_isatty`, as that appears to be more reliable
+        if (function_exists('posix_isatty')) {
+            return posix_isatty(STDIN);
+        }
         if (method_exists('\Symfony\Component\Process\Process', 'isTtySupported')) {
             return Process::isTtySupported();
         }


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no 
| Has tests?    | yes/sortof
| BC breaks?    | no     
| Deprecations? | no 

### Summary
The Symfony method for detecting ttys does not seem to be as reliable as `posix_isatty`, so we will favor the later if it is available.