### PR TITLE
Fixes #33: Better error reporting when output does not contain json.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,10 +24,11 @@ install:
   - git clone -q https://github.com/acquia/DevDesktopCommon.git #For tar, cksum, ...
   - SET PATH=%APPVEYOR_BUILD_FOLDER%/DevDesktopCommon/bintools-win/msys/bin;%PATH%
   - SET PATH=C:\Program Files\MySql\MySQL Server 5.7\bin\;%PATH%
+  - choco search php --exact --all-versions -r
   #Install PHP per https://blog.wyrihaximus.net/2016/11/running-php-unit-tests-on-windows-using-appveyor-and-chocolatey/
   - ps: Set-Service wuauserv -StartupType Manual
   - ps: appveyor-retry cinst --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $Env:php_ver_target | Select-Object -first 1) -replace '[php|]','')
-  - cd c:\tools\php71
+  - cd c:\tools\php73
   - copy php.ini-production php.ini
 
   - echo extension_dir=ext >> php.ini
@@ -44,7 +45,7 @@ install:
   - echo extension=php_pdo_sqlite.dll >> php.ini
   - echo extension=php_pgsql.dll >> php.ini
   - echo extension=php_gd2.dll >> php.ini
-  - SET PATH=C:\tools\php71;%PATH%
+  - SET PATH=C:\tools\php73;%PATH%
   #Install Composer
   - cd %APPVEYOR_BUILD_FOLDER%
   #- appveyor DownloadFile https://getcomposer.org/composer.phar
@@ -61,4 +62,4 @@ test_script:
 # environment variables
 environment:
   global:
-      php_ver_target: 7.1
+      php_ver_target: 7.3

--- a/src/ProcessBase.php
+++ b/src/ProcessBase.php
@@ -178,10 +178,14 @@ class ProcessBase extends Process
             // Revert of doubled backslashes.
             $output = preg_replace('#\\\\{2}#', '\\', $output);
         }
-        $output = $this->removeNonJsonJunk($output);
-        $json = json_decode($output, true);
+        $sanitizedOutput = $this->removeNonJsonJunk($output);
+        $json = json_decode($sanitizedOutput, true);
         if (!isset($json)) {
-            throw new \InvalidArgumentException('Unable to decode output into JSON.');
+            $msg = 'Unable to decode output into JSON: ' . json_last_error_msg();
+            if (json_last_error() == JSON_ERROR_SYNTAX) {
+                $msg .= "\n\n$output";
+            }
+            throw new \InvalidArgumentException($msg);
         }
         return $json;
     }

--- a/tests/SiteProcessTest.php
+++ b/tests/SiteProcessTest.php
@@ -227,7 +227,7 @@ class SiteProcessTest extends TestCase
                 'LINUX',
             ],
             [
-                'Unable to decode output into JSON.',
+                "Unable to decode output into JSON: Syntax error\n\nNo json data here",
                 'No json data here',
                 NULL,
             ],


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | no 

### Summary
When the output of a command cannot be converted into JSON, then information about the cause of the error is included in the exception. The original text is also included if the error is a syntax error.