### PR TITLE
Relax constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         "php": ">=7.1.3",
         "consolidation/config": "^1.2.1|^2",
         "consolidation/site-alias": "^3",
-        "symfony/process": "^4.3.4|^5|^6",
-        "symfony/console": "^2.8.52|^3|^4.4|^5|^6"
+        "symfony/process": "^4.3.4|^5",
+        "symfony/console": "^2.8.52|^3|^4.4|^5"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3",

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         "php": ">=7.1.3",
         "consolidation/config": "^1.2.1|^2",
         "consolidation/site-alias": "^3",
-        "symfony/process": "^4.3.4",
-        "symfony/console": "^2.8.52|^3|^4.4|^5"
+        "symfony/process": "^4.3.4|^5|^6",
+        "symfony/console": "^2.8.52|^3|^4.4|^5|^6"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d10658bc84c3a1ecd9330f35ea2eb01b",
+    "content-hash": "14eb523cbea293d8ec41a5a424bfcf51",
     "packages": [
         {
             "name": "consolidation/config",
@@ -1576,9 +1576,6 @@
             },
             "require": {
                 "php": "^7.1 || ^8.0"
-            },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
@@ -3312,5 +3309,5 @@
     "platform-overrides": {
         "php": "7.2.28"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/src/ProcessBase.php
+++ b/src/ProcessBase.php
@@ -226,7 +226,7 @@ class ProcessBase extends Process
      */
     private function overrideCommandLine($commandline)
     {
-        $commandlineSetter = function($commandline) {
+        $commandlineSetter = function ($commandline) {
             $this->commandline = $commandline;
         };
         $commandlineSetter->bindTo($this, Process::class)();

--- a/src/ProcessBase.php
+++ b/src/ProcessBase.php
@@ -226,9 +226,10 @@ class ProcessBase extends Process
      */
     private function overrideCommandLine($commandline)
     {
-        $property = new \ReflectionProperty(Process::class, "commandline");
-        $property->setAccessible(true);
-        $property->setValue($this, $commandline);
+        $commandlineSetter = function($commandline) {
+            $this->commandline = $commandline;
+        };
+        $commandlineSetter->bindTo($this, Process::class)();
         return $this;
     }
 }

--- a/src/ProcessBase.php
+++ b/src/ProcessBase.php
@@ -131,14 +131,14 @@ class ProcessBase extends Process
         if ($this->isSimulated()) {
             $this->getLogger()->notice('Simulating: ' . $cmd);
             // Run a command that always succeeds (on Linux and Windows).
-            $this->setCommandLine('true');
+            $this->overrideCommandLine('true');
         } elseif ($this->isVerbose()) {
             $this->getLogger()->info('Executing: ' . $cmd);
         }
         parent::start($callback, $env);
         // Set command back to original value in case anyone asks.
         if ($this->isSimulated()) {
-            $this->setCommandLine($cmd);
+            $this->overrideCommandLine($cmd);
         }
     }
 
@@ -212,5 +212,23 @@ class ProcessBase extends Process
         $realTimeOutput = new RealtimeOutputHandler($this->realtimeStdout(), $this->realtimeStderr());
         $realTimeOutput->configure($this);
         return $realTimeOutput;
+    }
+
+    /**
+     * Overrides the command line to be executed.
+     *
+     * @param string|array $commandline The command to execute
+     *
+     * @return $this
+     *
+     * @todo refactor library so this hack to get around changes in
+     *   symfony/process 5 is unnecessary.
+     */
+    private function overrideCommandLine($commandline)
+    {
+        $property = new \ReflectionProperty(Process::class, "commandline");
+        $property->setAccessible(true);
+        $property->setValue($this, $commandline);
+        return $this;
     }
 }

--- a/src/SiteProcess.php
+++ b/src/SiteProcess.php
@@ -11,6 +11,7 @@ use Consolidation\Config\Util\Interpolator;
 use Consolidation\SiteProcess\Util\Shell;
 use Consolidation\SiteProcess\Util\ShellOperatorInterface;
 use Consolidation\SiteProcess\Util\Escape;
+use Symfony\Component\Process\Process;
 
 /**
  * A wrapper around Symfony Process that uses site aliases
@@ -188,7 +189,7 @@ class SiteProcess extends ProcessBase
             $processedArgs = $this->processArgs();
             $commandLine = Escape::argsForSite($this->siteAlias, $processedArgs);
             $commandLine = implode(' ', $commandLine);
-            $this->setCommandLine($commandLine);
+            $this->overrideCommandLine($commandLine);
         }
         return $commandLine;
     }
@@ -240,5 +241,23 @@ class SiteProcess extends ProcessBase
             },
             $args
         );
+    }
+
+    /**
+     * Overrides the command line to be executed.
+     *
+     * @param string|array $commandline The command to execute
+     *
+     * @return $this
+     *
+     * @todo refactor library so this hack to get around changes in
+     *   symfony/process 5 is unnecessary.
+     */
+    private function overrideCommandLine($commandline)
+    {
+        $property = new \ReflectionProperty(Process::class, "commandline");
+        $property->setAccessible(true);
+        $property->setValue($this, $commandline);
+        return $this;
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | yes
| BC breaks?    | kinda because on upstream Symfony changes.     
| Deprecations? | no 

### Summary
Allow installation on Drupal 10 by extending constraints to allow Symfony 5

### Description
The current code is using \Symfony\Component\Process\Process::setCommandLine() - this method is deprecated in SF4 and removed from SF5. Unfortunately the use-cases are fundamental to what is being done in \Consolidation\SiteProcess\ProcessBase to support command simulation and in \Consolidation\SiteProcess\SiteProcess to support site aliases.

The obvious hack to use reflection access the \Symfony\Component\Process\Process::$commandline property for now and then fix this in a new version of this.

For more info: https://github.com/symfony/symfony/issues/36988.


