### PR TITLE
Fix overrideCommandLine() use of bindTo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           composer --working-dir=tools require roave/backward-compatibility-check:^5
 
       - name: Run roave/backward-compatibility-check
-        run: ./tools/vendor/bin/roave-backward-compatibility-check --from=4.1.0
+        run: ./tools/vendor/bin/roave-backward-compatibility-check --from=4.1.2
 
   tests:
     name: Tests

--- a/src/ProcessBase.php
+++ b/src/ProcessBase.php
@@ -229,7 +229,7 @@ class ProcessBase extends Process
         $commandlineSetter = function ($commandline) {
             $this->commandline = $commandline;
         };
-        $commandlineSetter->bindTo($this, Process::class)();
+        $commandlineSetter->bindTo($this, Process::class)($commandline);
         return $this;
     }
 }

--- a/src/SiteProcess.php
+++ b/src/SiteProcess.php
@@ -272,7 +272,7 @@ class SiteProcess extends ProcessBase
         $commandlineSetter = function ($commandline) {
             $this->commandline = $commandline;
         };
-        $commandlineSetter->bindTo($this, Process::class)();
+        $commandlineSetter->bindTo($this, Process::class)($commandline);
         return $this;
     }
 }

--- a/src/SiteProcess.php
+++ b/src/SiteProcess.php
@@ -269,9 +269,10 @@ class SiteProcess extends ProcessBase
      */
     private function overrideCommandLine($commandline)
     {
-        $property = new \ReflectionProperty(Process::class, "commandline");
-        $property->setAccessible(true);
-        $property->setValue($this, $commandline);
+        $commandlineSetter = function ($commandline) {
+            $this->commandline = $commandline;
+        };
+        $commandlineSetter->bindTo($this, Process::class)();
         return $this;
     }
 }


### PR DESCRIPTION
Start with a failing test: copy ProcessBase::overrideCommandLine() to SiteProcess.
