### PR TITLE
Implement a new kubectl transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+* Support kubectl transport (#60)
+
 ### 4.1.3 / 4.1.2 - 2022/Jan/18
 
 * Support symfony/process ^5 via illicit access to a private member (#58)

--- a/src/Factory/KubectlTransportFactory.php
+++ b/src/Factory/KubectlTransportFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Consolidation\SiteProcess\Factory;
+
+use Consolidation\SiteAlias\SiteAliasInterface;
+use Consolidation\SiteProcess\Transport\KubectlTransport;
+
+/**
+ * KubectlTransportFactory will create an KubectlTransport for applicable site aliases.
+ */
+class KubectlTransportFactory implements TransportFactoryInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function check(SiteAliasInterface $siteAlias)
+    {
+        return $siteAlias->has('kubectl');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function create(SiteAliasInterface $siteAlias)
+    {
+        return new KubectlTransport($siteAlias);
+    }
+}

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -2,6 +2,7 @@
 
 namespace Consolidation\SiteProcess;
 
+use Consolidation\SiteProcess\Factory\KubectlTransportFactory;
 use Consolidation\SiteProcess\Factory\VagrantTransportFactory;
 use Psr\Log\LoggerInterface;
 use Consolidation\SiteAlias\SiteAliasInterface;
@@ -68,6 +69,7 @@ class ProcessManager implements ConfigAwareInterface
     public static function addTransports(ProcessManager $processManager)
     {
         $processManager->add(new SshTransportFactory());
+        $processManager->add(new KubectlTransportFactory());
         $processManager->add(new DockerComposeTransportFactory());
         $processManager->add(new VagrantTransportFactory());
 

--- a/src/Transport/KubectlTransport.php
+++ b/src/Transport/KubectlTransport.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Consolidation\SiteProcess\Transport;
+
+use Consolidation\SiteProcess\SiteProcess;
+use Consolidation\SiteProcess\Util\Escape;
+use Consolidation\SiteAlias\SiteAliasInterface;
+use Consolidation\SiteProcess\Util\Shell;
+
+/**
+ * KubectlTransport knows how to wrap a command such that it runs in a container
+ * on Kubernetes via kubectl.
+ */
+class KubectlTransport implements TransportInterface
+{
+    /** @var bool */
+    protected $tty;
+
+    /** @var \Consolidation\SiteAlias\SiteAliasInterface */
+    protected $siteAlias;
+
+    public function __construct(SiteAliasInterface $siteAlias)
+    {
+        $this->siteAlias = $siteAlias;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function configure(SiteProcess $process)
+    {
+        $this->tty = $process->isTty();
+    }
+
+    /**
+     * inheritdoc
+     */
+    public function wrap($args)
+    {
+        # TODO: How/where do we complain if a required argument is not available?
+        $namespace = $this->siteAlias->get('kubectl.namespace');
+        $tty = $this->tty && $this->siteAlias->get('kubectl.tty', false) ? "true" : "false";
+        $interactive = $this->tty && $this->siteAlias->get('kubectl.interactive', false) ? "true" : "false";
+        $resource = $this->siteAlias->get('kubectl.resource');
+        $container = $this->siteAlias->get('kubectl.container');
+
+        $transport = [
+            'kubectl',
+            "--namespace=$namespace",
+            'exec',
+            "--tty=$tty",
+            "--stdin=$interactive",
+            $resource,
+            "--container=$container",
+            "--",
+        ];
+
+        return array_merge(
+            $transport,
+            Escape::argsForSite($this->siteAlias, $args)
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addChdir($cd_remote, $args)
+    {
+        return array_merge(
+            [
+                'cd',
+                $cd_remote,
+                Shell::op('&&'),
+            ],
+            $args
+        );
+    }
+
+}

--- a/src/Transport/KubectlTransport.php
+++ b/src/Transport/KubectlTransport.php
@@ -51,9 +51,11 @@ class KubectlTransport implements TransportInterface
             "--tty=$tty",
             "--stdin=$interactive",
             $resource,
-            "--container=$container",
-            "--",
         ];
+        if ($container) {
+            $transport[] = "--container=$container";
+        }
+        $transport[] = "--";
 
         return array_merge(
             $transport,

--- a/src/Transport/KubectlTransport.php
+++ b/src/Transport/KubectlTransport.php
@@ -73,5 +73,4 @@ class KubectlTransport implements TransportInterface
             $args
         );
     }
-
 }

--- a/src/Transport/KubectlTransport.php
+++ b/src/Transport/KubectlTransport.php
@@ -3,7 +3,6 @@
 namespace Consolidation\SiteProcess\Transport;
 
 use Consolidation\SiteProcess\SiteProcess;
-use Consolidation\SiteProcess\Util\Escape;
 use Consolidation\SiteAlias\SiteAliasInterface;
 use Consolidation\SiteProcess\Util\Shell;
 
@@ -57,10 +56,7 @@ class KubectlTransport implements TransportInterface
         }
         $transport[] = "--";
 
-        return array_merge(
-            $transport,
-            Escape::argsForSite($this->siteAlias, $args)
-        );
+        return array_merge($transport, $args);
     }
 
     /**

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -5,8 +5,8 @@ namespace Consolidation\SiteProcess\Transport;
 use Consolidation\SiteProcess\SiteProcess;
 
 /**
- * SshTransport knows how to wrap a command such that it runs on a remote
- * system via the ssh cli.
+ * Transports know how to wrap a command such that it runs on a remote system
+ * via some other command.
  *
  * There is always a transport for every factory, and visa-versa.
  *

--- a/tests/Transport/KubectlTransportTest.php
+++ b/tests/Transport/KubectlTransportTest.php
@@ -17,6 +17,7 @@ class KubectlTransportTest extends TestCase
             // Everything explicit.
             [
                 'kubectl --namespace=vv exec --tty=false --stdin=false deploy/drupal --container=drupal -- ls',
+                ['ls'],
                 [
                     'kubectl' => [
                         'tty' => false,
@@ -31,6 +32,19 @@ class KubectlTransportTest extends TestCase
             // Minimal. Kubectl will pick a container.
             [
                 'kubectl --namespace=vv exec --tty=false --stdin=false deploy/drupal -- ls',
+                ['ls'],
+                [
+                    'kubectl' => [
+                        'namespace' => 'vv',
+                        'resource' => 'deploy/drupal',
+                    ]
+                ],
+            ],
+
+            // Don't escape arguments after "--"
+            [
+                'kubectl --namespace=vv exec --tty=false --stdin=false deploy/drupal -- asdf "double" \'single\'',
+                ['asdf', '"double"', "'single'"],
                 [
                     'kubectl' => [
                         'namespace' => 'vv',
@@ -44,11 +58,11 @@ class KubectlTransportTest extends TestCase
     /**
      * @dataProvider wrapTestValues
      */
-    public function testWrap($expected, $siteAliasData)
+    public function testWrap($expected, $args, $siteAliasData)
     {
         $siteAlias = new SiteAlias($siteAliasData, '@alias.dev');
         $dockerTransport = new KubectlTransport($siteAlias);
-        $actual = $dockerTransport->wrap(['ls']);
+        $actual = $dockerTransport->wrap($args);
         $this->assertEquals($expected, implode(' ', $actual));
     }
 }

--- a/tests/Transport/KubectlTransportTest.php
+++ b/tests/Transport/KubectlTransportTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Consolidation\SiteProcess;
+
+use Consolidation\SiteProcess\Transport\KubectlTransport;
+use PHPUnit\Framework\TestCase;
+use Consolidation\SiteAlias\SiteAlias;
+
+class KubectlTransportTest extends TestCase
+{
+    /**
+     * Data provider for testWrap.
+     */
+    public function wrapTestValues()
+    {
+        return [
+            // Everything explicit.
+            [
+                'kubectl --namespace=vv exec --tty=false --stdin=false deploy/drupal --container=drupal -- ls',
+                [
+                    'kubectl' => [
+                        'tty' => false,
+                        'interactive' => false,
+                        'namespace' => 'vv',
+                        'resource' => 'deploy/drupal',
+                        'container' => 'drupal',
+                    ]
+                ],
+            ],
+
+            // Minimal. Kubectl will pick a container.
+            [
+                'kubectl --namespace=vv exec --tty=false --stdin=false deploy/drupal -- ls',
+                [
+                    'kubectl' => [
+                        'namespace' => 'vv',
+                        'resource' => 'deploy/drupal',
+                    ]
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider wrapTestValues
+     */
+    public function testWrap($expected, $siteAliasData)
+    {
+        $siteAlias = new SiteAlias($siteAliasData, '@alias.dev');
+        $dockerTransport = new KubectlTransport($siteAlias);
+        $actual = $dockerTransport->wrap(['ls']);
+        $this->assertEquals($expected, implode(' ', $actual));
+    }
+}


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Implement a new kubectl transport for accessing Drupal instances running in Kubernetes.

### Description

If you have this alias:

```yaml
foo:
  paths:
    drush-script: /vv/vendor/bin/drush
  root: /vv/web
  uri: drupal.example.com
  kubectl:
    tty: false
    interactive: false
    namespace: vv
    resource: deploy/drupal-deployment
    container: drupal
```

... you can do this:

```shell
drush @foo status
```

... or any other drush command, and it will run via kubectl, like this:

```shell
kubectl --namespace=vv exec --tty=false --stdin=false deploy/drupal-deployment --container=drupal -- /vv/vendor/bin/drush status --uri=drupal.example.com --root=/vv/web
```