### PR TITLE
Add custom transport to allow wrapping with any command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+* Adds a new option to site aliases which lets users specify any command to wrap invoked processes (#61).
+
 ### 4.1.3 / 4.1.2 - 2022/Jan/18
 
 * Support symfony/process ^5 via illicit access to a private member (#58)

--- a/src/Factory/CustomTransportFactory.php
+++ b/src/Factory/CustomTransportFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Consolidation\SiteProcess\Factory;
+
+use Consolidation\SiteAlias\SiteAliasInterface;
+use Consolidation\SiteProcess\Transport\CustomTransport;
+use Consolidation\Config\ConfigInterface;
+
+/**
+ * CustomTransportFactory will create an CustomTransport for applicable site aliases.
+ */
+class CustomTransportFactory implements TransportFactoryInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function check(SiteAliasInterface $siteAlias)
+    {
+        return $siteAlias->has('command');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function create(SiteAliasInterface $siteAlias)
+    {
+        return new CustomTransport($siteAlias);
+    }
+}

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -5,6 +5,7 @@ namespace Consolidation\SiteProcess;
 use Consolidation\SiteProcess\Factory\VagrantTransportFactory;
 use Psr\Log\LoggerInterface;
 use Consolidation\SiteAlias\SiteAliasInterface;
+use Consolidation\SiteProcess\Factory\CustomTransportFactory;
 use Consolidation\SiteProcess\Factory\SshTransportFactory;
 use Consolidation\SiteProcess\Factory\DockerComposeTransportFactory;
 use Consolidation\SiteProcess\Factory\TransportFactoryInterface;
@@ -70,6 +71,7 @@ class ProcessManager implements ConfigAwareInterface
         $processManager->add(new SshTransportFactory());
         $processManager->add(new DockerComposeTransportFactory());
         $processManager->add(new VagrantTransportFactory());
+        $processManager->add(new CustomTransportFactory());
 
         return $processManager;
     }

--- a/src/Transport/CustomTransport.php
+++ b/src/Transport/CustomTransport.php
@@ -35,13 +35,14 @@ class CustomTransport implements TransportInterface
      */
     public function wrap($args)
     {
-        $transport = Shell::preEscaped($this->siteAlias->get('custom.command', ''));
+        $cmd = $this->siteAlias->get('custom.command', '');
+        $transport = $cmd ? [Shell::preEscaped($cmd)] : [];
         $commandToExecute = $this->getCommandToExecute($args);
 
-        return array_merge(
+        return array_filter(array_merge(
             $transport,
             $commandToExecute
-        );
+        ));
     }
 
     /**

--- a/src/Transport/CustomTransport.php
+++ b/src/Transport/CustomTransport.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Consolidation\SiteProcess\Transport;
+
+use Consolidation\SiteProcess\SiteProcess;
+use Consolidation\SiteProcess\Util\Escape;
+use Consolidation\SiteAlias\SiteAliasInterface;
+use Consolidation\SiteProcess\Util\Shell;
+use Consolidation\Config\ConfigInterface;
+
+/**
+ * CustomTransport knows how to wrap a command such that it runs within
+ * any cli.
+ */
+class CustomTransport implements TransportInterface
+{
+    protected $tty;
+    protected $siteAlias;
+
+    public function __construct(SiteAliasInterface $siteAlias)
+    {
+        $this->siteAlias = $siteAlias;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function configure(SiteProcess $process)
+    {
+        $this->tty = $process->isTty();
+    }
+
+    /**
+     * inheritdoc
+     */
+    public function wrap($args)
+    {
+        $transport = Shell::preEscaped($this->siteAlias->get('custom.command', ''));
+        $commandToExecute = $this->getCommandToExecute($args);
+
+        return array_merge(
+            $transport,
+            $commandToExecute
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addChdir($cd_remote, $args)
+    {
+        // Make no assumptions about the CLI and what it can support.
+        // The CLI itself should handle this with the options specified
+        // in the custom command.
+        return [];
+    }
+
+    /**
+     * getCommandToExecute processes the arguments for the command to
+     * be executed such that they are appropriate for the transport mechanism.
+     */
+    protected function getCommandToExecute($args)
+    {
+        // Escape each argument for the target system and then join
+        $args = Escape::argsForSite($this->siteAlias, $args);
+        $commandToExecute = implode(' ', $args);
+
+        return [$commandToExecute];
+    }
+}

--- a/tests/Transport/CustomTransportTest.php
+++ b/tests/Transport/CustomTransportTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Consolidation\SiteProcess;
+
+use Consolidation\SiteProcess\Transport\CustomTransport;
+use PHPUnit\Framework\TestCase;
+use Consolidation\SiteAlias\SiteAlias;
+
+class CustomTransportTest extends TestCase
+{
+    /**
+     * Data provider for testWrap.
+     */
+    public function wrapTestValues()
+    {
+        return [
+            [
+                'ls',
+                [
+                    'custom' => [
+                        'command' => '',
+                    ],
+                ],
+            ],
+            [
+                'platform ls',
+                [
+                    'custom' => [
+                        'command' => 'platform',
+                    ],
+                ],
+            ],
+            [
+                'platform -e dev ls',
+                [
+                    'custom' => [
+                        'command' => 'platform -e dev',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider wrapTestValues
+     */
+    public function testWrap($expected, $siteAliasData)
+    {
+        $siteAlias = new SiteAlias($siteAliasData, '@alias.dev');
+        $dockerTransport = new CustomTransport($siteAlias);
+        $actual = $dockerTransport->wrap(['ls']);
+        $this->assertEquals($expected, implode(' ', $actual));
+    }
+}

--- a/tests/Transport/CustomTransportTest.php
+++ b/tests/Transport/CustomTransportTest.php
@@ -47,8 +47,8 @@ class CustomTransportTest extends TestCase
     public function testWrap($expected, $siteAliasData)
     {
         $siteAlias = new SiteAlias($siteAliasData, '@alias.dev');
-        $dockerTransport = new CustomTransport($siteAlias);
-        $actual = $dockerTransport->wrap(['ls']);
+        $customTransport = new CustomTransport($siteAlias);
+        $actual = $customTransport->wrap(['ls']);
         $this->assertEquals($expected, implode(' ', $actual));
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | no 

### Summary
This adds a new option to site aliases which lets users specify any command to wrap invoked processes (such as drush).

### Description
More details in #52.
