### PR TITLE
Add support for kubeconfig on KubectlTransport.php

### DIFF
--- a/src/Transport/KubectlTransport.php
+++ b/src/Transport/KubectlTransport.php
@@ -56,7 +56,7 @@ class KubectlTransport implements TransportInterface
             $transport[] = "--container=$container";
         }
         if ($kubeconfig) {
-           $transport[] = "--kubeconfig=$kubeconfig";
+            $transport[] = "--kubeconfig=$kubeconfig";
         }
         $transport[] = "--";
 

--- a/src/Transport/KubectlTransport.php
+++ b/src/Transport/KubectlTransport.php
@@ -42,6 +42,7 @@ class KubectlTransport implements TransportInterface
         $interactive = $this->tty && $this->siteAlias->get('kubectl.interactive', false) ? "true" : "false";
         $resource = $this->siteAlias->get('kubectl.resource');
         $container = $this->siteAlias->get('kubectl.container');
+        $kubeconfig = $this->siteAlias->get('kubectl.kubeconfig');
 
         $transport = [
             'kubectl',
@@ -53,6 +54,9 @@ class KubectlTransport implements TransportInterface
         ];
         if ($container) {
             $transport[] = "--container=$container";
+        }
+        if ($kubeconfig) {
+           $transport[] = "--kubeconfig=$kubeconfig";
         }
         $transport[] = "--";
 

--- a/tests/Transport/KubectlTransportTest.php
+++ b/tests/Transport/KubectlTransportTest.php
@@ -52,6 +52,22 @@ class KubectlTransportTest extends TestCase
                     ]
                 ],
             ],
+
+            // With kubeconfig.
+            [
+                'kubectl --namespace=vv exec --tty=false --stdin=false deploy/drupal --container=drupal --kubeconfig=/path/to/config.yaml -- ls',
+                ['ls'],
+                [
+                    'kubectl' => [
+                        'tty' => false,
+                        'interactive' => false,
+                        'namespace' => 'vv',
+                        'resource' => 'deploy/drupal',
+                        'container' => 'drupal',
+                        'kubeconfig' => '/path/to/config.yaml',
+                    ]
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Adds support for the option `--kubeconfig` when using KubectlTransport.php

### Description
If specified it will add the path to a kubeconfig file like this:
```
kubectl --namespace=vv exec --tty=false --stdin=false deploy/drupal-deployment --container=drupal --kubeconfig=/path/to/kubeconfig.yaml -- /vv/vendor/bin/drush status --uri=drupal.example.com --root=/vv/web
```