### PR TITLE
Transport support for Skpr

### DIFF
--- a/src/Factory/SkprTransportFactory.php
+++ b/src/Factory/SkprTransportFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Consolidation\SiteProcess\Factory;
+
+use Consolidation\SiteAlias\SiteAliasInterface;
+use Consolidation\SiteProcess\Transport\SkprTransport;
+
+/**
+ * SkprTransportFactory will create an SkprTransport for applicable site aliases.
+ */
+class SkprTransportFactory implements TransportFactoryInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function check(SiteAliasInterface $siteAlias)
+    {
+        return $siteAlias->has('skpr');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function create(SiteAliasInterface $siteAlias)
+    {
+        return new SkprTransport($siteAlias);
+    }
+}

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -3,6 +3,7 @@
 namespace Consolidation\SiteProcess;
 
 use Consolidation\SiteProcess\Factory\KubectlTransportFactory;
+use Consolidation\SiteProcess\Factory\SkprTransportFactory;
 use Consolidation\SiteProcess\Factory\VagrantTransportFactory;
 use Psr\Log\LoggerInterface;
 use Consolidation\SiteAlias\SiteAliasInterface;
@@ -70,6 +71,7 @@ class ProcessManager implements ConfigAwareInterface
     {
         $processManager->add(new SshTransportFactory());
         $processManager->add(new KubectlTransportFactory());
+        $processManager->add(new SkprTransportFactory());
         $processManager->add(new DockerComposeTransportFactory());
         $processManager->add(new VagrantTransportFactory());
 

--- a/src/Transport/SkprTransport.php
+++ b/src/Transport/SkprTransport.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Consolidation\SiteProcess\Transport;
+
+use Consolidation\SiteProcess\SiteProcess;
+use Consolidation\SiteAlias\SiteAliasInterface;
+use Consolidation\SiteProcess\Util\Shell;
+
+/**
+ * SkprTransport knows how to wrap a command to run on a site hosted
+ * on the Skpr platform.
+ */
+class SkprTransport implements TransportInterface
+{
+
+    /** @var \Consolidation\SiteAlias\SiteAliasInterface */
+    protected $siteAlias;
+
+    public function __construct(SiteAliasInterface $siteAlias)
+    {
+        $this->siteAlias = $siteAlias;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function configure(SiteProcess $process)
+    {
+        $path = $this->siteAlias->getDefault('skpr.path', getcwd());
+        if ($path) {
+            $process->chdirToSiteRoot($path);
+        }
+    }
+
+    /**
+     * inheritdoc
+     */
+    public function wrap($args)
+    {
+        $environment = $this->siteAlias->get('skpr.env');
+
+        $transport = [
+            'skpr',
+            'exec',
+            "$environment",
+        ];
+        $transport[] = "--";
+
+        return array_merge($transport, $args);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addChdir($cd_remote, $args)
+    {
+        return array_merge(
+            [
+                'cd',
+                $cd_remote,
+                Shell::op('&&'),
+            ],
+            $args
+        );
+    }
+}

--- a/tests/Transport/SkprTransportTest.php
+++ b/tests/Transport/SkprTransportTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Consolidation\SiteProcess;
+
+use Consolidation\SiteProcess\Transport\SkprTransport;
+use PHPUnit\Framework\TestCase;
+use Consolidation\SiteAlias\SiteAlias;
+
+class SkprTransportTest extends TestCase
+{
+    /**
+     * Data provider for testWrap.
+     */
+    public function wrapTestValues()
+    {
+        return [
+            // Everything explicit.
+            [
+                'skpr exec dev -- ls',
+                ['ls'],
+                [
+                    'skpr' => [
+                        'environment' => 'dev',
+                    ]
+                ],
+            ],
+
+            // Ensure we aren't escaping arguments after "--"
+            [
+                'skpr exec dev -- monday "tuesday" \'wednesday\'',
+                ['monday', '"tuesday"', "'wednesday'"],
+                [
+                    'skpr' => [
+                        'environment' => 'dev'
+                    ]
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider wrapTestValues
+     */
+    public function testWrap($expected, $args, $siteAliasData)
+    {
+        $siteAlias = new SiteAlias($siteAliasData, '@alias.dev');
+        $dockerTransport = new SkprTransport($siteAlias);
+        $actual = $dockerTransport->wrap($args);
+        $this->assertEquals($expected, implode(' ', $actual));
+    }
+}

--- a/tests/Transport/SkprTransportTest.php
+++ b/tests/Transport/SkprTransportTest.php
@@ -20,7 +20,7 @@ class SkprTransportTest extends TestCase
                 ['ls'],
                 [
                     'skpr' => [
-                        'environment' => 'dev',
+                        'env' => 'dev',
                     ]
                 ],
             ],
@@ -31,7 +31,7 @@ class SkprTransportTest extends TestCase
                 ['monday', '"tuesday"', "'wednesday'"],
                 [
                     'skpr' => [
-                        'environment' => 'dev'
+                        'env' => 'dev'
                     ]
                 ],
             ],


### PR DESCRIPTION
### Overview

This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | no 

### Summary

Enables support for Drush commands to wrap skpr commands, enabling users on the Skpr platform to be able to use Drush and/or Drush focused scripts for management, migration, debugging etc.

### Description

I really loved that this could enable me to interface with Drupal via kubectl commands, we saw this as an opportunity to do the same with our `skpr` command line tool - because developers using our platform won't have access to kubectl for their day-to-day work.

I've modeled this work based on the kubectl transport work, and it's working quite nicely.
