### PR TITLE
Allow to set an entrypoint on KubectlTransport

### DIFF
--- a/src/Transport/KubectlTransport.php
+++ b/src/Transport/KubectlTransport.php
@@ -43,6 +43,7 @@ class KubectlTransport implements TransportInterface
         $resource = $this->siteAlias->get('kubectl.resource');
         $container = $this->siteAlias->get('kubectl.container');
         $kubeconfig = $this->siteAlias->get('kubectl.kubeconfig');
+        $entrypoint = $this->siteAlias->get('kubectl.entrypoint');
 
         $transport = [
             'kubectl',
@@ -59,6 +60,9 @@ class KubectlTransport implements TransportInterface
             $transport[] = "--kubeconfig=$kubeconfig";
         }
         $transport[] = "--";
+        if ($entrypoint) {
+            $transport = is_array($entrypoint) ? [...$transport, ...$entrypoint] : [...$transport, $entrypoint];
+        }
 
         return array_merge($transport, $args);
     }

--- a/tests/Transport/KubectlTransportTest.php
+++ b/tests/Transport/KubectlTransportTest.php
@@ -68,6 +68,38 @@ class KubectlTransportTest extends TestCase
                     ]
                 ],
             ],
+
+            // With entrypoint as string.
+            [
+                'kubectl --namespace=vv exec --tty=false --stdin=false deploy/drupal --container=drupal -- /docker-entrypoint ls',
+                ['ls'],
+                [
+                    'kubectl' => [
+                        'tty' => false,
+                        'interactive' => false,
+                        'namespace' => 'vv',
+                        'resource' => 'deploy/drupal',
+                        'container' => 'drupal',
+                        'entrypoint' => '/docker-entrypoint',
+                    ]
+                ],
+            ],
+
+            // With entrypoint as array.
+            [
+                'kubectl --namespace=vv exec --tty=false --stdin=false deploy/drupal --container=drupal -- /docker-entrypoint --debug ls',
+                ['ls'],
+                [
+                    'kubectl' => [
+                        'tty' => false,
+                        'interactive' => false,
+                        'namespace' => 'vv',
+                        'resource' => 'deploy/drupal',
+                        'container' => 'drupal',
+                        'entrypoint' => ['/docker-entrypoint', '--debug'],
+                    ]
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Allow to set a entrypoint to wrap the command to be executed in the container via kubetcl.

Docker containers often use an entrypoint script to prepare the environment to be able to execute a command. Our usecase is to be able to wrap 'drush' calls in '/vault/vault-env' as we use Banzaicloud BankVaults to load/expose secrets from Hashicorp Vault.

### Description
If specified it will add the entrypoint just before the original args:
`kubectl --namespace=vv exec --tty=false --stdin=false deploy/drupal-deployment --container=drupal -- /vault/vault-env /vv/vendor/bin/drush status --uri=drupal.example.com --root=/vv/web`
