### PR TITLE
Allow to set the kubectl --cluster option

### DIFF
--- a/src/Transport/KubectlTransport.php
+++ b/src/Transport/KubectlTransport.php
@@ -37,6 +37,7 @@ class KubectlTransport implements TransportInterface
     public function wrap($args)
     {
         # TODO: How/where do we complain if a required argument is not available?
+        $cluster = $this->siteAlias->get('kubectl.cluster');
         $namespace = $this->siteAlias->get('kubectl.namespace');
         $tty = $this->tty && $this->siteAlias->get('kubectl.tty', false) ? "true" : "false";
         $interactive = $this->tty && $this->siteAlias->get('kubectl.interactive', false) ? "true" : "false";
@@ -47,7 +48,15 @@ class KubectlTransport implements TransportInterface
 
         $transport = [
             'kubectl',
-            "--namespace=$namespace",
+        ];
+        if ($cluster) {
+            $transport[] = "--cluster=$cluster";
+        }
+        if ($namespace) {
+            $transport[] = "--namespace=$namespace";
+        }
+        $transport = [
+            ...$transport,
             'exec',
             "--tty=$tty",
             "--stdin=$interactive",

--- a/tests/Transport/KubectlTransportTest.php
+++ b/tests/Transport/KubectlTransportTest.php
@@ -16,12 +16,13 @@ class KubectlTransportTest extends TestCase
         return [
             // Everything explicit.
             [
-                'kubectl --namespace=vv exec --tty=false --stdin=false deploy/drupal --container=drupal -- ls',
+                'kubectl --cluster=b --namespace=vv exec --tty=false --stdin=false deploy/drupal --container=drupal -- ls',
                 ['ls'],
                 [
                     'kubectl' => [
                         'tty' => false,
                         'interactive' => false,
+                        'cluster' => 'cluster-b',
                         'namespace' => 'vv',
                         'resource' => 'deploy/drupal',
                         'container' => 'drupal',


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | no 

### Summary
This PR allow to set the "cluster" for the kubectl transport. This is useful when working with multiple clusters.

### Description
Note that this is also useful in combination with #64; a kubeconfig file can contain multiple clusters.

Note there are multiple other options we could pass:
https://kubernetes.io/docs/reference/kubectl/kubectl/

Maybe we should look for a way to use all available options. For now I only need the cluster option.
