### PR TITLE
Docker compose v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 4.2.2 - 2023/Jul/4
+
+* Allow Docker Compose v2
+
 ### 4.2.1 - 2022/Oct/18
 
 * Allow site-alias ^4

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ local:
   docker:
     service: drupal
     compose:
+      version: 1
       options: --project dockerComposeProjectName --file docker-compose.yml --project-directory dockerComposeWorkDir
     exec:
       options: --user www-data
@@ -78,7 +79,12 @@ docker-compose --project dockerComposeProjectName --file docker-compose.yml --pr
 
 `docker.project` and `compose.options --project` do the same thing, docker.project existed before options.
 
-`docker.service` is the exact name of the service as it appears in docker-compos.yml
+`docker.service` is the exact name of the service as it appears in docker-compose.yml
+
+`docker.compose.version` defaults to `1`.  Set to `2` to use the new syntax:
+```
+docker compose --project dockerComposeProjectName --file docker-compose.yml --project-directory dockerComposeWorkDir exec --user www-data -T drupal
+```
 
 Check the [docker-compose](https://docs.docker.com/compose/reference/overview/) manual for all available options.
 

--- a/src/Transport/DockerComposeTransport.php
+++ b/src/Transport/DockerComposeTransport.php
@@ -61,7 +61,7 @@ class DockerComposeTransport implements TransportInterface
      */
     protected function getTransport()
     {
-        $version = $this->siteAlias->get('docker.version', '1');
+        $version = $this->siteAlias->get('docker.compose.version', '1');
         if ($version == 2) {
             $transport = ['docker', 'compose'];
         }

--- a/src/Transport/DockerComposeTransport.php
+++ b/src/Transport/DockerComposeTransport.php
@@ -64,8 +64,7 @@ class DockerComposeTransport implements TransportInterface
         $version = $this->siteAlias->get('docker.compose.version', '1');
         if ($version == 2) {
             $transport = ['docker', 'compose'];
-        }
-        else {
+        } else {
             $transport = ['docker-compose'];
         }
         $project = $this->siteAlias->get('docker.project', '');

--- a/src/Transport/DockerComposeTransport.php
+++ b/src/Transport/DockerComposeTransport.php
@@ -61,7 +61,13 @@ class DockerComposeTransport implements TransportInterface
      */
     protected function getTransport()
     {
-        $transport = ['docker-compose'];
+        $version = $this->siteAlias->get('docker.version', '1');
+        if ($version == 2) {
+            $transport = ['docker', 'compose'];
+        }
+        else {
+            $transport = ['docker-compose'];
+        }
         $project = $this->siteAlias->get('docker.project', '');
         $options = $this->siteAlias->get('docker.compose.options', '');
         if ($project && (strpos($options, '-p') === false || strpos($options, '--project') === false)) {

--- a/tests/Transport/DockerComposeTransportTest.php
+++ b/tests/Transport/DockerComposeTransportTest.php
@@ -39,7 +39,9 @@ class DockerComposeTransportTest extends TestCase
                 [
                     'docker' => [
                         'service' => 'drupal',
-                        'version' => '2',
+                        'compose' => [
+                            'version' => '2',
+                        ],
                     ]
                 ],
             ],
@@ -48,7 +50,9 @@ class DockerComposeTransportTest extends TestCase
                 [
                     'docker' => [
                         'service' => 'drupal',
-                        'version' => '1',
+                        'compose' => [
+                            'version' => '1',
+                        ]
                     ]
                 ],
             ],

--- a/tests/Transport/DockerComposeTransportTest.php
+++ b/tests/Transport/DockerComposeTransportTest.php
@@ -35,6 +35,24 @@ class DockerComposeTransportTest extends TestCase
                 ],
             ],
             [
+                'docker compose exec -T drupal ls',
+                [
+                    'docker' => [
+                        'service' => 'drupal',
+                        'version' => '2',
+                    ]
+                ],
+            ],
+            [
+                'docker-compose exec -T drupal ls',
+                [
+                    'docker' => [
+                        'service' => 'drupal',
+                        'version' => '1',
+                    ]
+                ],
+            ],
+            [
                 'docker-compose --project project2 --file myCompose.yml exec -T drupal ls',
                 [
                     'docker' => [


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Allows using docker compose v2 syntax when calling the transport

### Description
With calling a command with the newest docker desktop installed a EOL message appears
```
WARNING: Compose V1 is no longer supported and will be removed from Docker Desktop in an upcoming release. See https://docs.docker.com/go/compose-v1-eol/
```
Docker Compose v2 is mostly backwards compatible (see https://docs.docker.com/compose/migrate/) so most people should just be able to switch over with minimal changes but this branch still keeps the default version to 1 just in case.