### PR TITLE
Allow short options. Needed to pass along -vvv

### DIFF
--- a/src/Util/ArgumentProcessor.php
+++ b/src/Util/ArgumentProcessor.php
@@ -13,6 +13,9 @@ use Consolidation\SiteProcess\Transport\TransportInterface;
  */
 class ArgumentProcessor
 {
+
+    const SHORT_OPTION = '-short';
+
     /**
      * selectArgs selects the appropriate set of arguments for the command
      * to be executed and orders them as needed.
@@ -28,7 +31,7 @@ class ArgumentProcessor
     public function selectArgs(SiteAliasInterface $siteAlias, $args, $options = [], $optionsPassedAsArgs = [])
     {
         // Split args into three arrays separated by the `--`
-        list($leadingArgs, $dashDash, $remaingingArgs) = $this->findArgSeparator($args);
+        [$leadingArgs, $dashDash, $remaingingArgs] = $this->findArgSeparator($args);
         $convertedOptions = $this->convertOptions($options);
         $convertedOptionsPassedAsArgs = $this->convertOptions($optionsPassedAsArgs);
 
@@ -83,7 +86,7 @@ class ArgumentProcessor
         foreach ($options as $option => $value) {
             if ($value === true || $value === null) {
                 $result[] = "--$option";
-            } elseif ($value === '-short') {
+            } elseif ($value === self::SHORT_OPTION) {
                 $result[] = "-$option";
             } elseif ($value === false) {
                 // Ignore this option.

--- a/src/Util/ArgumentProcessor.php
+++ b/src/Util/ArgumentProcessor.php
@@ -83,6 +83,8 @@ class ArgumentProcessor
         foreach ($options as $option => $value) {
             if ($value === true || $value === null) {
                 $result[] = "--$option";
+            } elseif ($value === '-short') {
+                $result[] = "-$option";
             } elseif ($value === false) {
                 // Ignore this option.
             } else {

--- a/src/Util/ArgumentProcessor.php
+++ b/src/Util/ArgumentProcessor.php
@@ -13,8 +13,17 @@ use Consolidation\SiteProcess\Transport\TransportInterface;
  */
 class ArgumentProcessor
 {
+    private $short_options = ['vv', 'vvv'];
 
-    const SHORT_OPTION = '-short';
+    public function getShortOptions(): array
+    {
+        return $this->short_options;
+    }
+
+    public function setShortOptions(array $short_options): void
+    {
+        $this->short_options = $short_options;
+    }
 
     /**
      * selectArgs selects the appropriate set of arguments for the command
@@ -31,7 +40,7 @@ class ArgumentProcessor
     public function selectArgs(SiteAliasInterface $siteAlias, $args, $options = [], $optionsPassedAsArgs = [])
     {
         // Split args into three arrays separated by the `--`
-        [$leadingArgs, $dashDash, $remaingingArgs] = $this->findArgSeparator($args);
+        list($leadingArgs, $dashDash, $remaingingArgs) = $this->findArgSeparator($args);
         $convertedOptions = $this->convertOptions($options);
         $convertedOptionsPassedAsArgs = $this->convertOptions($optionsPassedAsArgs);
 
@@ -84,17 +93,21 @@ class ArgumentProcessor
     {
         $result = [];
         foreach ($options as $option => $value) {
+            $dashes = str_repeat('-', $this->dashCount($option));
             if ($value === true || $value === null) {
-                $result[] = "--$option";
-            } elseif ($value === self::SHORT_OPTION) {
-                $result[] = "-$option";
+                $result[] = $dashes . $option;
             } elseif ($value === false) {
                 // Ignore this option.
             } else {
-                $result[] = "--{$option}={$value}";
+                $result[] = "{$dashes}{$option}={$value}";
             }
         }
 
         return $result;
+    }
+
+    protected function dashCount($name): int
+    {
+        return in_array($name, $this->getShortOptions()) ? 1 : 2;
     }
 }

--- a/tests/ArgumentProcessorTest.php
+++ b/tests/ArgumentProcessorTest.php
@@ -26,7 +26,7 @@ class ArgumentProcessorTest extends TestCase
                 '["drush", "status", "-vvv", "--fields=root,uri"]',
                 [],
                 ['drush', 'status'],
-                ['vvv' => '-short', 'fields' => 'root,uri'],
+                ['vvv' => TRUE, 'fields' => 'root,uri'],
                 [],
             ],
 

--- a/tests/ArgumentProcessorTest.php
+++ b/tests/ArgumentProcessorTest.php
@@ -23,10 +23,10 @@ class ArgumentProcessorTest extends TestCase
             ],
 
             [
-                '["drush", "status", "--fields=root,uri"]',
+                '["drush", "status", "-vvv", "--fields=root,uri"]',
                 [],
                 ['drush', 'status'],
-                ['fields' => 'root,uri'],
+                ['vvv' => '-short', 'fields' => 'root,uri'],
                 [],
             ],
 


### PR DESCRIPTION
--verbose=3 is not allowed by its InputDefinition. --verbose does not accept a value (i.e. is VALUE_NONE). It must be passed as short option.

So we enable convertOptions() to pass along short options via a magic value `-short`. Magic values of true and false are already supported so hopefully this doesnt smell too bad.

This enables a fix for https://github.com/drush-ops/drush/pull/5948

