### PR TITLE
Forward-port docker compose v2 support to main (5.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 5.4.1 - 2024/Jul/10
+
+* Allow Docker Compose v2
+
 ### 5.4.0
 
 * Support Symfony 7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Site Process
 
-A thin wrapper around the Symfony Process Component that allows applications to use the Site Alias library to specify the target for a remote call. 
+A thin wrapper around the Symfony Process Component that allows applications to use the Site Alias library to specify the target for a remote call.
 
 [![ci](https://github.com/consolidation/site-process/workflows/CI/badge.svg)](https://travis-ci.org/consolidation/site-process)
 [![scrutinizer](https://scrutinizer-ci.com/g/consolidation/site-process/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/consolidation/site-process/?branch=master)
@@ -41,7 +41,7 @@ local:
   host: localhost
   uri: http://localhost
   ssh:
-    options: -o PasswordAuthentication=no -i $HOME/.ssh/id_rsa 
+    options: -o PasswordAuthentication=no -i $HOME/.ssh/id_rsa
 
 ```
 ### Vagrant
@@ -65,6 +65,7 @@ local:
   docker:
     service: drupal
     compose:
+      version: 1
       options: --project dockerComposeProjectName --file docker-compose.yml --project-directory dockerComposeWorkDir
     exec:
       options: --user www-data
@@ -80,6 +81,11 @@ docker-compose --project dockerComposeProjectName --file docker-compose.yml --pr
 
 `docker.service` is the exact name of the service as it appears in docker-compose.yml
 
+`docker.compose.version` defaults to `1`. Set to `2` to use the new syntax:
+
+```
+docker compose --project dockerComposeProjectName --file docker-compose.yml --project-directory dockerComposeWorkDir exec --user www-data -T drupal
+```
 The default behaviour is to use `docker-compose exec` to invoke a command on a running container.
 You can change this to use `docker-compose run` for containers which by default are not running, with the property `compose.command`.
 
@@ -97,7 +103,7 @@ The test suite may be run locally by way of some simple composer scripts:
 | Run all tests    | `composer test`
 | PHPUnit tests    | `composer unit`
 | PHP linter       | `composer lint`
-| Code style       | `composer cs`     
+| Code style       | `composer cs`
 | Fix style errors | `composer cbf`
 
 

--- a/src/Transport/DockerComposeTransport.php
+++ b/src/Transport/DockerComposeTransport.php
@@ -61,7 +61,12 @@ class DockerComposeTransport implements TransportInterface
      */
     protected function getTransport()
     {
-        $transport = ['docker-compose'];
+        $version = $this->siteAlias->get('docker.compose.version', '1');
+        if ($version == 2) {
+            $transport = ['docker', 'compose'];
+        } else {
+            $transport = ['docker-compose'];
+        }
         $project = $this->siteAlias->get('docker.project', '');
         $options = $this->siteAlias->get('docker.compose.options', '');
         $command = $this->siteAlias->get('docker.compose.command', 'exec');

--- a/tests/Transport/DockerComposeTransportTest.php
+++ b/tests/Transport/DockerComposeTransportTest.php
@@ -35,6 +35,28 @@ class DockerComposeTransportTest extends TestCase
                 ],
             ],
             [
+                'docker compose exec -T drupal ls',
+                [
+                    'docker' => [
+                        'service' => 'drupal',
+                        'compose' => [
+                            'version' => '2',
+                        ],
+                    ]
+                ],
+            ],
+            [
+                'docker-compose exec -T drupal ls',
+                [
+                    'docker' => [
+                        'service' => 'drupal',
+                        'compose' => [
+                            'version' => '1',
+                        ]
+                    ]
+                ],
+            ],
+            [
                 'docker-compose --project project2 --file myCompose.yml exec -T drupal ls',
                 [
                     'docker' => [


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- don't forget to update CHANGELOG.md files -->
| Has tests?    | yes/no
| BC breaks?    | no     
| Deprecations? | yes/no 

### Summary
Allows using docker compose v2 syntax when calling the transport

### Description
This was implemented and merged into the 4.x branch but not into the latest supported main (5.x). This PR forward-ports the changes to the `main` (5.x) branch. See #75 and https://github.com/consolidation/site-process/pull/75#issuecomment-1868309555
