### PR TITLE
PHP 8.4 compatibility: implicitly nullable parameter declarations deprecated

### DIFF
--- a/src/ProcessBase.php
+++ b/src/ProcessBase.php
@@ -125,7 +125,7 @@ class ProcessBase extends Process
     /**
      * @inheritDoc
      */
-    public function start(callable $callback = null, array $env = []): void
+    public function start(?callable $callback = null, array $env = []): void
     {
         $cmd = $this->getCommandLine();
         if ($this->isSimulated()) {

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -103,7 +103,7 @@ class ProcessManager implements ConfigAwareInterface
      * @param int|float|null $timeout The timeout in seconds or null to disable
      * @return Process
      */
-    public function process($command, $cwd = null, array $env = null, $input = null, $timeout = 60)
+    public function process($command, $cwd = null, ?array $env = null, $input = null, $timeout = 60)
     {
         return new ProcessBase($command, $cwd, $env, $input, $timeout);
     }
@@ -117,7 +117,7 @@ class ProcessManager implements ConfigAwareInterface
      * @param int|float|null $timeout The timeout in seconds or null to disable
      * @return Process
      */
-    public function shell($command, $cwd = null, array $env = null, $input = null, $timeout = 60)
+    public function shell($command, $cwd = null, ?array $env = null, $input = null, $timeout = 60)
     {
         return ProcessBase::fromShellCommandline($command, $cwd, $env, $input, $timeout);
     }

--- a/src/SiteProcess.php
+++ b/src/SiteProcess.php
@@ -198,13 +198,13 @@ class SiteProcess extends ProcessBase
     /**
      * @inheritDoc
      */
-    public function start(callable $callback = null, array $env = []): void
+    public function start(?callable $callback = null, array $env = []): void
     {
         $cmd = $this->getCommandLine();
         parent::start($callback, $env);
     }
 
-    public function mustRun(callable $callback = null, array $env = []): static
+    public function mustRun(?callable $callback = null, array $env = []): static
     {
         if (0 !== $this->run($callback, $env)) {
             // Be less verbose when there is nothing in stdout or stderr.
@@ -220,7 +220,7 @@ class SiteProcess extends ProcessBase
     /**
      * @inheritDoc
      */
-    public function wait(callable $callback = null): int
+    public function wait(?callable $callback = null): int
     {
         $return = parent::wait($callback);
         return $return;


### PR DESCRIPTION
Ref https://github.com/drush-ops/drush/issues/6069

### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | yes

### Summary
Fixed all nullable type declarations found

### Description
Testing with official docker image `docker run --rm -v $(pwd):/mnt -w /mnt php:8.4.0alpha2-cli-alpine find src -type f -name '*.php' -exec php -l {} \;`
