### PR TITLE
Allow Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         "php": ">=8.2",
         "consolidation/config": "^2 || ^3",
         "consolidation/site-alias": "^3 || ^4",
-        "symfony/process": "^5 || ^6 || ^7",
-        "symfony/console": "^5.4 || ^6 || ^7"
+        "symfony/process": "^5 || ^6 || ^7 || ^8",
+        "symfony/console": "^5.4 || ^6 || ^7 || ^8"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3f1fd10dcd691d7741c7b1e5750b6b5",
+    "content-hash": "77e3314ad3e27d09075ef99b228ef17a",
     "packages": [
         {
             "name": "consolidation/config",


### PR DESCRIPTION
Widen symfony/* constraints to allow ^8.

No code changes needed — the APIs used by this package are unchanged in Symfony 8.

Ref: https://github.com/drush-ops/drush/issues/6536